### PR TITLE
Shortens session name to comply with 64 char limit

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/lambda/src/new_account_iam_role.py
+++ b/lambda/src/new_account_iam_role.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 from aws_lambda_powertools import Logger
-from aws_assume_role_lib import assume_role, generate_lambda_session_name
+from aws_assume_role_lib import assume_role
 import boto3
 import botocore
 
@@ -105,7 +105,7 @@ def get_session(assume_role_arn):
     return assume_role(
         boto3.Session(),
         assume_role_arn,
-        RoleSessionName=generate_lambda_session_name(function_name),
+        RoleSessionName=function_name,
         DurationSeconds=3600,
         validate=False,
     )


### PR DESCRIPTION
Avoids errors of the sort:

```
Member must have length less than or equal to 64
```