### PR TITLE
Defaults to ignoring the source_code_hash logic in lambda module

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 1.0.1
+
+**Commit Delta**: [Change from 1.0.0 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/1.0.0...1.0.1)
+
+**Released**: 2022.10.19
+
+**Summary**:
+
+*   Defaults to ignoring the source code hash. Function is still updated whenever source_path contents change.
+
 ### 1.0.0
 
 **Commit Delta**: [Change from 0.4.2 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/0.4.2...1.0.0)

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ module "lambda" {
 
   artifacts_dir            = try(var.lambda.artifacts_dir, "builds")
   create_package           = try(var.lambda.create_package, true)
+  ignore_source_code_hash  = try(var.lambda.ignore_source_code_hash, true)
   local_existing_package   = try(var.lambda.local_existing_package, null)
   recreate_missing_package = try(var.lambda.recreate_missing_package, false)
 


### PR DESCRIPTION
Function is still updated whenever the source_path contents are modified, based on how the lambda module determines the filename.