### PR TITLE
Ignores terragrunt source manifest by default

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.2
+current_version = 1.0.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### 1.0.3
+
+**Commit Delta**: [Change from 1.0.2 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/1.0.2...1.0.3)
+
+**Released**: 2022.10.20
+
+**Summary**:
+
+*   Ignores terragrunt source manifest by default.
+*   Supports customizing the source_path patterns, using var.lambda.source_patterns.
+
 ### 1.0.2
 
 **Commit Delta**: [Change from 1.0.1 release](https://github.com/plus3it/terraform-aws-org-new-account-trust-policy/compare/1.0.1...1.0.2)

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,13 @@ module "lambda" {
   attach_policy_json = true
   policy_json        = data.aws_iam_policy_document.lambda.json
 
-  source_path = "${path.module}/lambda/src"
+  source_path = [
+    {
+      path             = "${path.module}/lambda/src"
+      pip_requirements = true
+      patterns         = try(var.lambda.source_patterns, ["!\\.terragrunt-source-manifest"])
+    }
+  ]
 
   artifacts_dir            = try(var.lambda.artifacts_dir, "builds")
   create_package           = try(var.lambda.create_package, true)


### PR DESCRIPTION
On init, Terragrunt is for some reason creating a source manifest file
in the lambda/src directory. That file contains fully-qualified paths,
which are often different on different systems (especially CICD pipelines).
The lambda packaging logic includes all the files by default, and generates
a unique name based on the hash of the directory contents. Since the
terragrunt manifest has unique paths on different systems, this causes
the built filename to change. The lambda module then plans out an
update to the lambda function, even though the source code has not
actually changed (just the terragrunt manifest).

This patch uses the source_path.patterns option to default ignore the
terragrunt manifest, while also allowing the user to override the patterns
using var.lambda.source_patterns. This allows this module to support
other deployment tooling around terraform, not just terragrunt.